### PR TITLE
Wrong Entity relations fix

### DIFF
--- a/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/model/definitions/FisaObject.java
+++ b/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/model/definitions/FisaObject.java
@@ -110,4 +110,9 @@ public class FisaObject {
     public void setAttributes(List<FisaObjectAttribute> attributes) {
         this.attributes = attributes;
     }
+
+    @Override
+    public String toString() {
+        return this.id + " " + this.definitionName;
+    }
 }

--- a/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/service/converter/FisaProjectToBundleConverter.java
+++ b/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/service/converter/FisaProjectToBundleConverter.java
@@ -12,6 +12,7 @@ import de.fraunhofer.iosb.ilt.fisabackend.service.generator.ExampleDataGenerator
 import de.fraunhofer.iosb.ilt.fisabackend.service.mapper.Mapper;
 import de.fraunhofer.iosb.ilt.fisabackend.service.mapper.MappingResolver;
 import de.fraunhofer.iosb.ilt.fisabackend.service.tree.FisaTree;
+import de.fraunhofer.iosb.ilt.fisabackend.service.tree.FisaTreeNode;
 import de.fraunhofer.iosb.ilt.fisabackend.util.StaUtil;
 import de.fraunhofer.iosb.ilt.sta.model.Datastream;
 import de.fraunhofer.iosb.ilt.sta.model.Entity;
@@ -157,18 +158,23 @@ public class FisaProjectToBundleConverter {
         for (FisaTree tree : fisaTrees) {
             // collect all entities of tree
             List<Entity<?>> collected = new ArrayList<>();
+            List<FisaTreeNode> nodesOfCollected = new ArrayList<>();
             tree.accept(node -> {
                 Entity<?> entity = node.getContext(Entity.class);
                 if (entity != null) {
                     collected.add(entity);
+                    nodesOfCollected.add(node);
                 }
             });
             // create STA relations between collected entities
             for (int outer = 0; outer < collected.size(); outer++) {
-                for (Entity<?> inner : collected) {
+                for (int inner = 0; inner < collected.size(); inner++) {
+                    Entity<?> to = collected.get(inner);
                     Entity<?> from = collected.get(outer);
-                    if (StaUtil.hasRelation(from.getType(), inner.getType())) {
-                        StaUtil.setInRelation(from, inner);
+                    // Check if the Objects and the Entity-Types are in relation
+                    if (StaUtil.hasChildRelation(nodesOfCollected.get(inner), nodesOfCollected.get(outer))
+                            && StaUtil.hasRelation(from.getType(), to.getType())) {
+                        StaUtil.setInRelation(from, to);
                     }
                 }
             }

--- a/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/service/tree/FisaTreeNode.java
+++ b/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/service/tree/FisaTreeNode.java
@@ -95,4 +95,9 @@ public class FisaTreeNode implements TreeNode<FisaObject, FisaTreeNode> {
     public final int hashCode() {
         return Objects.hash(parent, object);
     }
+
+    @Override
+    public String toString() {
+        return object.toString();
+    }
 }

--- a/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/util/StaUtil.java
+++ b/fisa-backend/src/main/java/de/fraunhofer/iosb/ilt/fisabackend/util/StaUtil.java
@@ -1,5 +1,6 @@
 package de.fraunhofer.iosb.ilt.fisabackend.util;
 
+import de.fraunhofer.iosb.ilt.fisabackend.service.tree.FisaTreeNode;
 import de.fraunhofer.iosb.ilt.sta.model.Datastream;
 import de.fraunhofer.iosb.ilt.sta.model.Entity;
 import de.fraunhofer.iosb.ilt.sta.model.EntityType;
@@ -47,6 +48,37 @@ public final class StaUtil {
             default:
                 return false;
         }
+    }
+
+    /**
+     * Check if the objects are in a children-relation
+     *
+     * @param o1 the first object to check
+     * @param o2 the second object to check
+     * @return true if there is a child-relation between this objects
+     */
+    public static boolean hasChildRelation(FisaTreeNode o1, FisaTreeNode o2) {
+        // Check if there is a direct relation of thees objects
+        if (o1.getValue().getChildren().contains(o2.getValue().getId())
+                || o2.getValue().getChildren().contains(o1.getValue().getId())) {
+            return true;
+        }
+
+        // check the children of o1
+        for (FisaTreeNode child: o1.getChildren()) {
+            if (hasChildRelation(child, o2)) {
+                return true;
+            }
+        }
+
+        // check the children of o2
+        for (FisaTreeNode child: o2.getChildren()) {
+            if (hasChildRelation(o1, child)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
In the FisaProjectToBundleConverter was a Bug, where the relations between entities just depend on whether ore not the Entity-Types are in relation. This caused that if there are more than one of the same Entity-Types always the last in the list was picked.
Because of that I added another Test witch checks if the objects are in a child-relation.